### PR TITLE
Fixes for ss4.6

### DIFF
--- a/client/css/SubscriptionPage.css
+++ b/client/css/SubscriptionPage.css
@@ -4,6 +4,7 @@
 
 #MailingLists li { width: auto; margin-right: 20px; padding: 6px 0 0; }
 
+#SendNotificationControlls li { width: 20% }
 #SendNotificationControlls li.active { border-bottom: 1px solid #D9D9D9; box-shadow: inset 0 1px 0 #757575; background: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #b5b5b5), color-stop(100%, #e7e7e7)); background: -moz-linear-gradient(#b5b5b5, #e7e7e7); background: -webkit-linear-gradient(#b5b5b5, #e7e7e7); background: -o-linear-gradient(#b5b5b5, #e7e7e7); background: linear-gradient(#b5b5b5, #e7e7e7); }
 
 .SendNotificationControlledPanel { display: none; }

--- a/docs/errors_fixed
+++ b/docs/errors_fixed
@@ -1,0 +1,7 @@
+Running SS-CMS 4.6.0
+[2020-11-04 16:03:37] error-log.ERROR: Uncaught Exception Error: "Call to a member function setTitle() on null" at /var/www/html/vendor/silverstripe/newsletter/src/Form/GridField/NewsletterGridFieldDetailForm_ItemRequest.php line 32 {"exception":"[object] (Error(code: 0): Call to a member function setTitle() on null at /var/www/html/vendor/silverstripe/newsletter/src/Form/GridField/NewsletterGridFieldDetailForm_ItemRequest.php:32)"} []
+
+Problem identified was the naming of the src/Form/GridField/NewsletterGridFieldDetailForm_ItemRequest.php line 31:
+$actions->fieldByName("action_doSave") this did return null and didn't initiate a recursive search.
+$actions->fieldByName("MajorActions.action_doSave") does.
+

--- a/docs/errors_fixed
+++ b/docs/errors_fixed
@@ -4,4 +4,3 @@ Running SS-CMS 4.6.0
 Problem identified was the naming of the src/Form/GridField/NewsletterGridFieldDetailForm_ItemRequest.php line 31:
 $actions->fieldByName("action_doSave") this did return null and didn't initiate a recursive search.
 $actions->fieldByName("MajorActions.action_doSave") does.
-

--- a/docs/errors_fixed
+++ b/docs/errors_fixed
@@ -4,3 +4,20 @@ Running SS-CMS 4.6.0
 Problem identified was the naming of the src/Form/GridField/NewsletterGridFieldDetailForm_ItemRequest.php line 31:
 $actions->fieldByName("action_doSave") this did return null and didn't initiate a recursive search.
 $actions->fieldByName("MajorActions.action_doSave") does.
+
+[2020-11-05 17:24:28] error-log.ERROR: Object->__call(): the method 'addCustomHeader' does not exist on 'SilverStripe\Newsletter\Control\Email\NewsletterEmail' {"exception":"[object] (BadMethodCallException(code: 0): Object->__call(): the method 'addCustomHeader' does not exist on 'SilverStripe\\Newsletter\\Control\\Email\\NewsletterEmail' at /sites/cinescuela/www/vendor/silverstripe/framework/src/Core/CustomMethods.php:54)"} []
+
+Method addCustomHeader is not part of the NewsletterEmail class or its parents, called in src/Model/SendRecipientQueue.php line 82
+    $email->addCustomHeader('Reply-To', $newsletter->ReplyTo);
+Because it's the only occurrence and is used for setting the Reply-To header, we can use
+    $email->setReplyTo($newsletter->ReplyTo);
+instead.
+
+Missing js requirement for 'Send notification Email to subscriber'
+
+Keep sequence of drag'n'drop order
+
+Keep selected checkbox on CheckboxSetWithExtraFields
+
+Show validation time for verification email in admin
+add translation for above

--- a/docs/errors_fixed
+++ b/docs/errors_fixed
@@ -21,3 +21,4 @@ Keep selected checkbox on CheckboxSetWithExtraFields
 
 Show validation time for verification email in admin
 add translation for above
+

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -146,3 +146,5 @@ en:
     DESCRIPTION: 'Generic content page'
     PLURALNAME: 'Unsubscription Pags'
     SINGULARNAME: 'Unsubscription Page'
+  Newsletter:
+    DaysVerificationIsValid: "The verification email is valid for %d days."

--- a/lang/en_GB.yml
+++ b/lang/en_GB.yml
@@ -71,3 +71,5 @@ en_GB:
     SENDFAIL: "Sending to the Following Recipients Failed"
     SENTOK: "Sending to the Following Recipients was Successful"
     SN: "Surname"
+  Newsletter:
+    DaysVerificationIsValid: "The verification email is valid for %d days."

--- a/lang/es.yml
+++ b/lang/es.yml
@@ -71,3 +71,5 @@ es:
     SENDFAIL: "El Wnvío a los Siguientes Destinatarios ha Fallado"
     SENTOK: "El envío a los Siguientes Destinatarios fue Exitoso"
     SN: "Apellidos"
+  Newsletter:
+    DaysVerificationIsValid: "El correo electrónico de verificación es válido %d días"

--- a/lang/es_MX.yml
+++ b/lang/es_MX.yml
@@ -71,3 +71,5 @@ es_MX:
     SENDFAIL: "El envío a los Siguientes Destinatarios ha Fallado"
     SENTOK: "El envío a los Siguientes Destinatarios fue Exitoso"
     SN: "Apellidos"
+  Newsletter:
+    DaysVerificationIsValid: "El correo electrónico de verificación es válido %d días"

--- a/src/Form/CheckboxSetWithExtraField.php
+++ b/src/Form/CheckboxSetWithExtraField.php
@@ -20,6 +20,8 @@ class CheckboxSetWithExtraField extends CheckboxSetField
     public $cellDisabled = array();
     public $tragable = true;
 
+    public $values;
+
     /**
      * Creates a new optionset field.
      *
@@ -35,14 +37,17 @@ class CheckboxSetWithExtraField extends CheckboxSetField
         $name,
         $title = "",
         $source = array(),
-        $extra = array(),
         $value = "",
+        $extra = array(),
         $extraValue = array(),
         $form = null
     ) {
         if (!empty($extra)) {
             $this->extra = $extra;
         }
+
+        $this->values = $value;
+
         if (!empty($extraValue)) {
             $this->extraValue = $extraValue;
         }
@@ -75,13 +80,18 @@ class CheckboxSetWithExtraField extends CheckboxSetField
     public function Field($properties = array())
     {
         $source = $this->source;
-        $values = $this->value;
+        $values = $this->values;
         // Get values from the join, if available
         if (is_object($this->form)) {
             $record = $this->form->getRecord();
-            if (!$values && $record && $record->hasMethod($this->name)) {
-                $funcName = $this->name;
-                $join = $record->$funcName();
+            if (!$values && $record) {
+                if ($record->hasMethod($this->name)) {
+                    $funcName = $this->name;
+                    $join = $record->$funcName();
+                } elseif ($record->hasField($this->name)) {
+                    $funcName = sprintf('%sAsArray', $this->name);
+                    $join = $record->$funcName();
+                }
                 if ($join) {
                     foreach ($join as $joinItem) {
                         $values[] = $joinItem->ID;

--- a/src/Form/GridField/NewsletterGridFieldDetailForm_ItemRequest.php
+++ b/src/Form/GridField/NewsletterGridFieldDetailForm_ItemRequest.php
@@ -28,7 +28,7 @@ class NewsletterGridFieldDetailForm_ItemRequest extends GridFieldDetailForm_Item
 
         if (empty($this->record->Status) || $this->record->Status == "Draft") {
             // save draft button
-            $actions->fieldByName("action_doSave")
+            $actions->fieldByName("MajorActions.action_doSave")
                 ->setTitle(_t('Newsletter.SAVE', "Save"))
                 ->removeExtraClass('ss-ui-action-constructive')
                 ->setAttribute('data-icon', 'addpage');

--- a/src/Model/Recipient.php
+++ b/src/Model/Recipient.php
@@ -279,19 +279,26 @@ class Recipient extends DataObject
         return $can;
     }
 
+    /**
+     * @param null $params
+     *
+     * @return FieldList
+     */
     public function getFrontEndFields($params = null)
     {
+        /** @var FieldList $fields */
         $fields = parent::getFrontEndFields($params);
-        $exludes = array(
+        $excludes = array(
             "BouncedCount",
             "Blacklisted",
             "ReceivedCount",
             "ValidateHash",
             "ValidateHashExpired",
             "Verified",
+            "GUID",
         );
 
-        foreach ($exludes as $exclude) {
+        foreach ($excludes as $exclude) {
             $fields->removeByName($exclude);
         }
 

--- a/src/Model/SendRecipientQueue.php
+++ b/src/Model/SendRecipientQueue.php
@@ -79,7 +79,7 @@ class SendRecipientQueue extends DataObject
             );
 
             if (!empty($newsletter->ReplyTo)) {
-                $email->addCustomHeader('Reply-To', $newsletter->ReplyTo);
+                $email->setReplyTo($newsletter->ReplyTo);
             }
 
             try {

--- a/src/Pagetypes/SubscriptionPage.php
+++ b/src/Pagetypes/SubscriptionPage.php
@@ -2,6 +2,8 @@
 
 namespace SilverStripe\Newsletter\Pagetypes;
 
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\Tab;
 use SilverStripe\Forms\HeaderField;
 use SilverStripe\Forms\TextField;
@@ -15,7 +17,25 @@ use SilverStripe\Newsletter\Model\MailingList;
 use SilverStripe\Newsletter\Form\CheckboxSetWithExtraField;
 use Page;
 use SilverStripe\Newsletter\Control\NewsletterAdmin;
+use SilverStripe\View\Requirements;
 
+/**
+ * Class SubscriptionPage
+ * @package SilverStripe\Newsletter\Pagetypes
+ *
+ * @property string $Fields    comma separated list of selected fields
+ * @property string $Required  JSON list of required fields e.g. { "Email":"1" }
+ * @property string $CustomisedHeading  Text before the subscription form
+ * @property string $CustomLabel    JSON Customized labels for the fields e.g. { "Email": "Email address" }
+ * @property string $ValidationMessage  JSON customized validation message for fields
+ *                                      e.g. { "Email": "An email address is required" }
+ * @property string $MailingLists   JSON list of available mailing list IDs for this subscription e.g. { "1", "5" }
+ * @property string $SubmissionButtonText Text to appear on the submit button (is not translated)
+ * @property bool $SendNotification     send a notification email to subscriber
+ * @property string $NotificationEmailSubject   Subject of the notification email
+ * @property string $NotificationEmailFrom  Sender-Email for the notification email
+ * @property string $OnCompleteMessage  Text to be shown when subscription process is completed
+ */
 class SubscriptionPage extends Page
 {
     private static $db = [
@@ -64,6 +84,17 @@ class SubscriptionPage extends Page
         }
     }
 
+    /**
+     * @return int configured number of days the subscription is valid
+     *             defaults to 2 if less then 2 or not set in config.
+     */
+    public static function get_days_verification_link_alive()
+    {
+        return SubscriptionPage::$days_verification_link_alive;
+    }
+    /**
+     * @InheritDoc
+     */
     public function getCMSFields()
     {
         $fields = parent::getCMSFields();
@@ -85,23 +116,35 @@ class SubscriptionPage extends Page
             new TextField('CustomisedHeading', 'Heading at the top of the form')
         );
 
-        //Fields selction
+        //Fields selection
+        /** @var array $frontFields [ fieldName => Field ] */
         $frontFields = singleton(Recipient::class)->getFrontEndFields()->dataFields();
 
-        $fieldCandidates = array();
+        $fieldCandidates = [];
+        // put all selected fields on top of the list of the available fields
+        $selectedFieldNames = explode(',', $this->Fields);
+        if (empty($selectedFieldNames)) {
+            $selectedFieldNames = ['Email'];
+        }
 
         if (count($frontFields)) {
+            foreach ($selectedFieldNames as $fieldName) {
+                if (array_key_exists($fieldName, $frontFields)) {
+                    $dataField = $frontFields[$fieldName];
+                    $fieldCandidates[$fieldName] = $dataField->Title()?$dataField->Title():$dataField->Name();
+                    unset($frontFields[$fieldName]);
+                    $values[$fieldName] = $fieldName;
+                }
+            }
             foreach ($frontFields as $fieldName => $dataField) {
                 $fieldCandidates[$fieldName]= $dataField->Title()?$dataField->Title():$dataField->Name();
             }
         }
 
         //Since Email field is the Recipient's identifier,
-        //and newsletters subscription is non-sence if no email is given by the user,
+        //and newsletters subscription is non-sense if no email is given by the user,
         //we should force that email to be checked and required.
-        //FisrtName should be checked as default, though it might not be required
-        $defaults = array("Email", "FirstName");
-
+        //FirstName should be checked as default, though it might not be required
         $extra = array('CustomLabel'=>"Varchar","ValidationMessage"=>"Varchar","Required" =>"Boolean");
         $extraValue = array(
             'CustomLabel'=>$this->CustomLabel,
@@ -109,17 +152,17 @@ class SubscriptionPage extends Page
             "Required" =>$this->Required
         );
 
-        $subscriptionTab->push(
-            $fieldsSelection = new CheckboxSetWithExtraField(
-                "Fields",
-                _t('Newsletter.SelectFields', "Select the fields to display on the subscription form"),
-                $fieldCandidates,
-                $extra,
-                $defaults,
-                $extraValue
-            )
+        $fieldsSelection = new CheckboxSetWithExtraField(
+            "Fields",
+            _t('Newsletter.SelectFields', "Select the fields to display on the subscription form"),
+            $fieldCandidates,
+            $selectedFieldNames,
+            $extra,
+            $extraValue
         );
 
+        $subscriptionTab->push($fieldsSelection);
+        // Email cannot be changed and is always required
         $fieldsSelection->setCellDisabled(array("Email"=>array("Value", "Required")));
 
         //Mailing Lists selection
@@ -153,6 +196,20 @@ class SubscriptionPage extends Page
 
         $subscriptionTab->push(
             new LiteralField(
+                'DaysVerificationIsValid',
+                sprintf(
+                    '<div id="DaysVerificationIsValid">'.
+                    _t('Newsletter.DaysVerificationIsValid', 'Validation for verification email is %d days').
+                    '<br/></div>',
+                    self::$days_verification_link_alive
+                )
+            )
+        );
+
+        Requirements::javascript('silverstripe/newsletter:client/javascript/SubscriptionPage.js');
+        Requirements::css('silverstripe/newsletter:client/css/SubscriptionPage.css');
+        $subscriptionTab->push(
+            new LiteralField(
                 'BottomTaskSelection',
                 sprintf(
                     '<div id="SendNotificationControlls" class="field actions">'.
@@ -166,6 +223,7 @@ class SubscriptionPage extends Page
                 )
             )
         );
+
 
         $subscriptionTab->push(
             CompositeField::create(
@@ -197,9 +255,55 @@ class SubscriptionPage extends Page
      * Email field is the member's identifier, and newsletters subscription is
      * non-sense if no email is given by the user, we should force that email
      * to be checked and required.
+     * @return string   JSON like {"Email":"1", "Surname": "1"}
      */
     public function getRequired()
     {
         return (!$this->getField('Required')) ? '{"Email":"1"}' : $this->getField('Required');
+    }
+
+    /**
+     * @param FieldList $frontEndFields FieldList of fields to be shown at the front-end.
+     *                                  This list are the fields for the Recipient without the excluded Fields
+     *
+     * @return FieldList    which contains only the selected fields for this Subscription Page in the selected order
+     */
+    public function getFrontendFieldList(FieldList  $frontEndFields)
+    {
+        if (empty($this->Fields)) {
+            $this->Fields = self::$defaults['Fields'];
+        }
+
+        $selectedFieldNames = explode(',', $this->Fields);
+        $selectedFrontEndFields = new FieldList();
+        foreach ($selectedFieldNames as $fieldName) {
+            $field = $frontEndFields->fieldByName($fieldName);
+            if ($field instanceof FormField) {
+                $selectedFrontEndFields->add($field);
+            }
+        }
+        return $selectedFrontEndFields;
+    }
+
+    /**
+     * @return array    list of required field names
+     *                  'Email' is always required and added to the list if missing
+     */
+    public function getRequiredFieldNames()
+    {
+        $requiredFieldNames = [];
+        $required = explode(',', trim($this->Required, '{}'));
+        foreach ($required as $requiredField) {
+            list($name, $one) = explode(':', $requiredField);
+            $name = trim($name, '"');
+            if (! empty($name)) {
+                $requiredFieldNames[] = $name;
+            }
+        }
+        // make sure that field Email is in the list
+        if (! in_array('Email', $requiredFieldNames)) {
+            $requiredFieldNames[] = 'Email';
+        }
+        return $requiredFieldNames;
     }
 }


### PR DESCRIPTION
Fixes "Call to a member function setTitle() on null" and the method 'addCustomHeader' does not exist on 'SilverStripe\Newsletter\Control\Email\NewsletterEmail, when installing this module on SS 4.6

I was not able to check the impact on other SS versions, Sorry